### PR TITLE
Volksbank compatibility

### DIFF
--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -76,6 +76,13 @@ class AccountBankStatementImportSheetMapping(models.Model):
         ],
         default='comma',
     )
+    header_relabel = fields.Char(
+        string='Relabel columns',
+        help=(
+            'Relabel columns, useful for missing column names. '
+            'For example "0:Timestamp,12:DebitCredit".'
+        ),
+    )
     quotechar = fields.Char(
         string='Text qualifier',
         size=1,

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -50,6 +50,20 @@ class AccountBankStatementImportSheetMapping(models.Model):
         ],
         default='utf-8',
     )
+    skip_lines_start = fields.Integer(
+        string='Skip lines at beginning',
+        help=(
+            'Amount of lines to skip in the beginning of the file before '
+            'trying to parse'
+        ),
+    )
+    skip_lines_end = fields.Integer(
+        string='Skip lines at end',
+        help=(
+            'Amount of lines to skip in the end of the file before '
+            'trying to parse'
+        ),
+    )
     delimiter = fields.Selection(
         string='Delimiter',
         selection=[

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -176,6 +176,9 @@ class AccountBankStatementImportSheetMapping(models.Model):
         string='Bank Account column',
         help='Partner\'s bank account',
     )
+    bank_account_iban_from_description = fields.Boolean(
+        string='Parse bank account from description'
+    )
 
     @api.onchange('float_thousands_sep')
     def onchange_thousands_separator(self):

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -51,17 +51,19 @@ class AccountBankStatementImportSheetMapping(models.Model):
         default='utf-8',
     )
     skip_lines_start = fields.Integer(
-        string='Skip lines at beginning',
+        string='Skip prefix lines',
         help=(
-            'Amount of lines to skip in the beginning of the file before '
-            'trying to parse'
+            'If the csv file has a heading area upfront the lines representing the table with the actual '
+            'bank statement lines, enter the number of lines to skip at the beginning of the file here. '
+            'The parser will ignore this amount of lines at the beginning of the file when trying to parse.'
         ),
     )
     skip_lines_end = fields.Integer(
-        string='Skip lines at end',
+        string='Skip suffix lines',
         help=(
-            'Amount of lines to skip in the end of the file before '
-            'trying to parse'
+            'If the csv file has a suffix area below the lines representing the table with the actual '
+            'bank statement lines, enter the number of lines to skip at the end of the file here. '
+            'The parser will ignore this amount of lines at the end of the file when trying to parse.'
         ),
     )
     delimiter = fields.Selection(
@@ -79,8 +81,10 @@ class AccountBankStatementImportSheetMapping(models.Model):
     header_relabel = fields.Char(
         string='Relabel columns',
         help=(
-            'Relabel columns, useful for missing column names. '
-            'For example "0:Timestamp,12:DebitCredit".'
+            'Relabel columns when the csv file has columns with missing labels which cannot be mapped to '
+            'their column counter parts in the mapping. Use the number of the column and the desired label '
+            'For example "0:Timestamp,12:DebitCredit". Use the customized labels in the columns section to '
+            'include the customized columns in the parsing process.'
         ),
     )
     quotechar = fields.Char(
@@ -153,9 +157,10 @@ class AccountBankStatementImportSheetMapping(models.Model):
     )
     merge_description_keep_newlines = fields.Integer(
         string='Merge description lines',
-        help=(
-            'Amount of lines to keep spearate when mergin description lines. '
-            'Will not merge lines when not set.'
+        help=('In csv files where the description column contains line breaks, this field can be used '
+              'to deal with them. Left blank no merging of line breaks will happen. Set to 0 all line breaks '
+              'will be removed. Any number stands for the amount of line breaks which will be kept '
+              'counting from the beginning e.g. 1 will erase all line breaks after the first one.'
         ),
     )
 
@@ -177,7 +182,10 @@ class AccountBankStatementImportSheetMapping(models.Model):
         help='Partner\'s bank account',
     )
     bank_account_iban_from_description = fields.Boolean(
-        string='Parse bank account from description'
+        string='Parse IBAN from description',
+        help='In cases where the bank csv file contains the IBAN Account numbers from counterparts in '
+             'the description column, you can check this box and the number will be parsed from the '
+             'description and filled in the bank account column in the bank statement line.',
     )
 
     @api.onchange('float_thousands_sep')

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -151,6 +151,14 @@ class AccountBankStatementImportSheetMapping(models.Model):
     description_column = fields.Char(
         string='Description column',
     )
+    merge_description_keep_newlines = fields.Integer(
+        string='Merge description lines',
+        help=(
+            'Amount of lines to keep spearate when mergin description lines. '
+            'Will not merge lines when not set.'
+        ),
+    )
+
     notes_column = fields.Char(
         string='Notes column',
     )

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -122,6 +122,10 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
             header = [str(value) for value in csv_or_xlsx[1].row_values(0)]
         else:
             header = [value.strip() for value in next(csv_or_xlsx)]
+        if mapping.header_relabel:
+            for action in mapping.header_relabel.split(','):
+                colnum, _, name = action.partition(':')
+                header[int(colnum)] = name
         timestamp_column = header.index(mapping.timestamp_column)
         currency_column = header.index(mapping.currency_column) \
             if mapping.currency_column else None

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -204,6 +204,12 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
             bank_account = values[bank_account_column] \
                 if bank_account_column is not None else None
 
+            if description and mapping.merge_description_keep_newlines is not None:
+                thresh = mapping.merge_description_keep_newlines
+                d_lines = description.splitlines()
+                d_lines = d_lines[:thresh] + ["".join(d_lines[thresh:])]
+                description = "\n".join(d_lines)
+
             if currency != currency_code:
                 continue
 

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -109,10 +109,14 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
                 csv_options['delimiter'] = csv_delimiter
             if mapping.quotechar:
                 csv_options['quotechar'] = mapping.quotechar
-            csv_or_xlsx = reader(
-                StringIO(data_file.decode(mapping.file_encoding or 'utf-8')),
-                **csv_options
-            )
+
+            decoded = data_file.decode(mapping.file_encoding or 'utf-8')
+            if mapping.skip_lines_start or mapping.skip_lines_end:
+                start = mapping.skip_lines_start or 0
+                end = -mapping.skip_lines_end if mapping.skip_lines_end else None
+                decoded = '\n'.join(decoded.splitlines()[start:end])
+
+            csv_or_xlsx = reader(StringIO(decoded), **csv_options)
 
         if isinstance(csv_or_xlsx, tuple):
             header = [str(value) for value in csv_or_xlsx[1].row_values(0)]

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from io import StringIO
 from os import path
 import itertools
+import re
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -267,6 +268,11 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
                 line['bank_name'] = bank_name
             if bank_account is not None:
                 line['bank_account'] = bank_account
+            elif mapping.bank_account_iban_from_description:
+                m = re.search(r'IBAN: ([^\s]+)', description)
+                if m is not None:
+                    line['bank_account'] = m.group(1)
+
             lines.append(line)
         return lines
 

--- a/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
+++ b/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
@@ -65,6 +65,7 @@
                         <field name='skip_lines_end'/>
                         <field name='header_relabel'/>
                         <field name='merge_description_keep_newlines'/>
+                        <field name='bank_account_iban_from_description'/>
                     </group>
                 </sheet>
             </form>

--- a/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
+++ b/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
@@ -28,16 +28,19 @@
                     </div>
                     <group>
                         <group>
-                            <field name="float_thousands_sep"/>
-                            <field name="float_decimal_sep"/>
-                        </group>
-                        <group>
                             <field name="file_encoding"/>
                             <field name="delimiter"/>
+                            <field name="float_thousands_sep"/>
+                            <field name="float_decimal_sep"/>
                             <field name="quotechar"/>
-                        </group>
-                        <group>
                             <field name="timestamp_format"/>
+                        </group>
+                        <group name="quirks">
+                            <field name='skip_lines_start'/>
+                            <field name='skip_lines_end'/>
+                            <field name='header_relabel'/>
+                            <field name='merge_description_keep_newlines'/>
+                            <field name='bank_account_iban_from_description'/>
                         </group>
                         <group attrs="{'invisible': [('debit_credit_column', '=', False)]}">
                             <field name="debit_value" attrs="{'required': [('debit_credit_column', '!=', False)]}"/>
@@ -59,13 +62,6 @@
                         <field name="partner_name_column"/>
                         <field name="bank_name_column"/>
                         <field name="bank_account_column"/>
-                    </group>
-                    <group string="Quirks">
-                        <field name='skip_lines_start'/>
-                        <field name='skip_lines_end'/>
-                        <field name='header_relabel'/>
-                        <field name='merge_description_keep_newlines'/>
-                        <field name='bank_account_iban_from_description'/>
                     </group>
                 </sheet>
             </form>

--- a/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
+++ b/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
@@ -60,6 +60,12 @@
                         <field name="bank_name_column"/>
                         <field name="bank_account_column"/>
                     </group>
+                    <group string="Quirks">
+                        <field name='skip_lines_start'/>
+                        <field name='skip_lines_end'/>
+                        <field name='header_relabel'/>
+                        <field name='merge_description_keep_newlines'/>
+                    </group>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
This adds the following features to `account_bank_statement_import_txt_xlsx` for compatibility with the CSV format used by Volksbank, GLS Bank and possibly others:
- skip lines at beginning and end of file
- add or rename column headings
- strip newlines from description
- parse receipient's IBAN from description